### PR TITLE
refactor: use external jar

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -41,3 +41,6 @@ metamaplite/
 ### env ###
 src/main/resources/*.env
 *.env
+
+### external metamaplite jar ###
+lib

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -14,7 +14,7 @@
 	<name>demo</name>
 	<description>UMLS</description>
 	<properties>
-		<java.version>20</java.version>
+		<java.version>17</java.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -52,11 +52,13 @@
 			<artifactId>spring-dotenv</artifactId>
 			<version>3.0.0</version>
 		</dependency>
-		<dependency>
-			<groupId>gov.nih.nlm.nls</groupId>
-			<artifactId>metamaplite</artifactId>
-			<version>3.6.2rc8</version>
-		</dependency>
+    <dependency>
+      <groupId>gov.nih.nlm.nls</groupId>
+      <artifactId>metamaplite</artifactId>
+      <version>3.6.2rc8</version>
+      <scope>system</scope>
+      <systemPath>${project.basedir}/lib/metamaplite-3.6.2rc8-standalone.jar</systemPath>
+    </dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/server/src/main/java/com/sscs/umls/UMLSSearchServiceImpl.java
+++ b/server/src/main/java/com/sscs/umls/UMLSSearchServiceImpl.java
@@ -7,9 +7,10 @@ import gov.nih.nlm.nls.metamap.lite.types.Ev;
 import gov.nih.nlm.nls.ner.MetaMapLite;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.core.io.ClassPathResource;
 
+import java.lang.ClassNotFoundException;
 import java.io.*;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -20,6 +21,15 @@ public class UMLSSearchServiceImpl implements UMLSSearchService {
 
     @Autowired
     private UMLSTermRepository umlsTermRepository;
+
+    private MetaMapLite metaMapLiteInst;
+
+    public UMLSSearchServiceImpl() throws IOException, ClassNotFoundException, InstantiationException, NoSuchMethodException, IllegalAccessException {
+        Properties properties = new Properties();
+        InputStream inStream = new ClassPathResource("metamaplite.properties").getInputStream();
+        properties.load(inStream);
+        metaMapLiteInst = new MetaMapLite(properties);
+    }
 
     @Override
     public List<UMLSTermEntity> searchDefinitionsByText(String queryText) throws Exception {
@@ -45,32 +55,8 @@ public class UMLSSearchServiceImpl implements UMLSSearchService {
         return umlsTermRepository.findByCui(cui);
     }
 
-
-    /**
-     * Set the MetaMapLite properties
-     *
-     * @param myProperties Properties object containing the MetaMapLite properties
-     * @throws IOException if the properties file cannot be read
-     */
-    private void setProperties(Properties myProperties) throws IOException, URISyntaxException {
-        MetaMapLite.expandModelsDir(myProperties, "/metamaplite/public_mm_lite/data/models");
-        MetaMapLite.expandIndexDir(myProperties, "/metamaplite/public_mm_lite/data/ivf/2022AB/USAbase");
-        myProperties.setProperty("metamaplite.excluded.termsfile", "/metamaplite/public_mm_lite/data/specialterms.txt");
-        InputStream inStream = getClass().getResourceAsStream("/metamaplite.properties");
-        myProperties.load(inStream);
-    }
-
-
     private List<String> mapQueryToCUIs(String queryText) throws Exception {
         try {
-            // Set MetaMapLite properties
-            Properties myProperties = new Properties();
-            setProperties(myProperties);
-
-            // Instantiate MetaMapLite instance
-            MetaMapLite metaMapLiteInst = new MetaMapLite(myProperties);
-
-
             // Process the input text
             BioCDocument document = FreeText.instantiateBioCDocument(queryText);
 


### PR DESCRIPTION
我改了什麼：
- Java 20 → 17
- 用 jar 取代 metamaplite 原始碼
- 把 metaMapLiteInst 轉為 Member

Java SE 20 不是長期支援版本（LTS），Spring Initializr 的預設版本也是 Java 17。除非很想用 20 的 feature，不然沒必要用 20。

我用 [MetaMapLite 3.6.2rc8 binary only Version](https://data.lhncbc.nlm.nih.gov/umls-restricted/ii/tools/MetaMap/download/metamaplite/public_mm_lite_3.6.2rc8_binaryonly.zip) 的 `target/metamaplite-3.6.2rc8-standalone.jar`，主要是免除了安裝 dependencies 的步驟。對了，standalone jar 要放在 lib 資料夾中。

metaMapLiteInst 原先是每次都會重新產生實例（甚至連 properties 都要重新讀），我將他拉到 Member，可以避免被垃圾收集器帶走。